### PR TITLE
feat: Detect changes in unmanaged pod spec

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,7 +78,10 @@ the operator in the same namespace as supervised workloads.
 1. Run the main method of the operator program:
 
    ```
-   $ go run cmd/operator/main.go
+   $ OPERATOR_NAMESPACE=starboard-operator \
+     OPERATOR_TARGET_NAMESPACES=starboard-operator \
+     OPERATOR_LOG_DEV_MODE=true \
+     go run cmd/operator/main.go
    ```
 
 ### Enable Aqua CSP scanner

--- a/deploy/kubectl/03-starboard-operator.role.yaml
+++ b/deploy/kubectl/03-starboard-operator.role.yaml
@@ -41,3 +41,4 @@ rules:
       - list
       - watch
       - create
+      - update

--- a/deploy/olm/bundle/0.0.1/starboard-operator.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/olm/bundle/0.0.1/starboard-operator.v0.0.1.clusterserviceversion.yaml
@@ -249,6 +249,7 @@ spec:
                 - list
                 - watch
                 - create
+                - update
       deployments:
         - name: starboard-operator
           spec:

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/aquasecurity/starboard v0.4.1-0.20200923101908-ca60574a118f
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/caarlos0/env/v6 v6.2.2
-	github.com/go-logr/logr v0.1.0
+	github.com/davecgh/go-spew v1.1.1
 	github.com/google/go-containerregistry v0.1.1
 	github.com/google/uuid v1.1.1
 	github.com/onsi/ginkgo v1.14.0

--- a/pkg/controller/controllers.go
+++ b/pkg/controller/controllers.go
@@ -1,0 +1,33 @@
+package controller
+
+import (
+	"fmt"
+	"hash"
+	"hash/fnv"
+
+	"github.com/davecgh/go-spew/spew"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+// ComputeHash returns a hash value calculated from pod spec.
+// The hash will be safe encoded to avoid bad words.
+func ComputeHash(spec corev1.PodSpec) string {
+	podSpecHasher := fnv.New32a()
+	DeepHashObject(podSpecHasher, spec)
+	return rand.SafeEncodeString(fmt.Sprint(podSpecHasher.Sum32()))
+}
+
+// DeepHashObject writes specified object to hash using the spew library
+// which follows pointers and prints actual values of the nested objects
+// ensuring the hash does not change when a pointer changes.
+func DeepHashObject(hasher hash.Hash, objectToWrite interface{}) {
+	hasher.Reset()
+	printer := spew.ConfigState{
+		Indent:         " ",
+		SortKeys:       true,
+		DisableMethods: true,
+		SpewKeys:       true,
+	}
+	printer.Fprintf(hasher, "%#v", objectToWrite)
+}

--- a/pkg/controller/controllers_test.go
+++ b/pkg/controller/controllers_test.go
@@ -1,0 +1,1 @@
+package controller_test

--- a/pkg/controller/controllers_test.go
+++ b/pkg/controller/controllers_test.go
@@ -1,1 +1,97 @@
 package controller_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aquasecurity/starboard-operator/pkg/controller"
+	"github.com/stretchr/testify/assert"
+	corev1 "k8s.io/api/core/v1"
+)
+
+func TestComputeHash(t *testing.T) {
+
+	booleanValue1 := true
+	booleanValue2 := true
+	booleanValue3 := false
+	booleanValue1Ptr := &booleanValue1
+	booleanValue2Ptr := &booleanValue2
+	booleanValue3Ptr := &booleanValue3
+
+	t.Run("Should return the same hash when pointers change but values stay the same", func(t *testing.T) {
+		spec1 := corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: booleanValue1Ptr,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:1.14.2",
+				},
+			},
+		}
+
+		spec2 := corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: booleanValue2Ptr,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:1.14.2",
+				},
+			},
+		}
+
+		assert.NotSame(t, booleanValue1Ptr, booleanValue2Ptr)
+		assert.Equal(t, booleanValue1, booleanValue2)
+		assert.Equal(t, controller.ComputeHash(spec1), controller.ComputeHash(spec2))
+	})
+
+	t.Run("Should return different hash when pointers point to different values", func(t *testing.T) {
+		spec1 := corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: booleanValue1Ptr,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:1.14.2",
+				},
+			},
+		}
+
+		spec2 := corev1.PodSpec{
+			SecurityContext: &corev1.PodSecurityContext{
+				RunAsNonRoot: booleanValue2Ptr,
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "nginx",
+					Image: "nginx:1.14.2",
+				},
+			},
+		}
+
+		assert.NotSame(t, booleanValue1Ptr, booleanValue3Ptr)
+		assert.NotEqual(t, booleanValue1, booleanValue3)
+		assert.Equal(t, controller.ComputeHash(spec1), controller.ComputeHash(spec2))
+	})
+
+	t.Run("Should return unique hashes", func(t *testing.T) {
+		hashes := make(map[string]bool)
+		for tag := 0; tag < 100; tag++ {
+			hash := controller.ComputeHash(corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  "nginx",
+						Image: fmt.Sprintf("nginx:%d", tag),
+					},
+				},
+			})
+			hashes[hash] = true
+		}
+		assert.Equal(t, 100, len(hashes))
+	})
+
+}

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -49,10 +49,11 @@ func (r *JobController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	job := &batchv1.Job{}
 	err := r.Client.Get(ctx, req.NamespacedName, job)
-	if err != nil && errors.IsNotFound(err) {
-		log.V(1).Info("Ignoring Job that must have been deleted")
-		return ctrl.Result{}, nil
-	} else if err != nil {
+	if err != nil {
+		if errors.IsNotFound(err) {
+			log.V(1).Info("Ignoring Job that must have been deleted")
+			return ctrl.Result{}, nil
+		}
 		return ctrl.Result{}, fmt.Errorf("getting job from cache: %w", err)
 	}
 

--- a/pkg/controller/job/job_controller.go
+++ b/pkg/controller/job/job_controller.go
@@ -63,15 +63,14 @@ func (r *JobController) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 
 	switch jobCondition := job.Status.Conditions[0].Type; jobCondition {
 	case batchv1.JobComplete:
-		err := r.processCompleteScanJob(ctx, job)
-		return ctrl.Result{}, err
+		err = r.processCompleteScanJob(ctx, job)
 	case batchv1.JobFailed:
-		err := r.processFailedScanJob(ctx, job)
-		return ctrl.Result{}, err
+		err = r.processFailedScanJob(ctx, job)
 	default:
-		log.Error(nil, "Unrecognized scan job condition", "condition", jobCondition)
-		return ctrl.Result{}, nil
+		err = fmt.Errorf("unrecognized scan job condition: %v", jobCondition)
 	}
+
+	return ctrl.Result{}, err
 }
 
 func (r *JobController) processCompleteScanJob(ctx context.Context, scanJob *batchv1.Job) error {

--- a/pkg/etc/config.go
+++ b/pkg/etc/config.go
@@ -8,6 +8,10 @@ import (
 	"github.com/caarlos0/env/v6"
 )
 
+const (
+	LabelPodSpecHash = "pod-spec-hash"
+)
+
 type VersionInfo struct {
 	Version string
 	Commit  string


### PR DESCRIPTION
This commit adds pod-spec-hash label to VulnerabilityReport
resources created by this operator. By doing that, when we
compare the acutal vs desired state we can detect changes
to pod descriptor, in particular image tag updates.

$ kubectl run nginx --image nginx:1.16
$ kubectl set image pod/nginx --image nginx:1.17

Resolves: #41

Signed-off-by: Daniel Pacak <pacak.daniel@gmail.com>