### PR TITLE
Add Helm chart

### DIFF
--- a/deploy/helm/.helmignore
+++ b/deploy/helm/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: starboard-operator
+description: A Helm chart for Kubernetes
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+appVersion: 1.16.0

--- a/deploy/helm/templates/NOTES.txt
+++ b/deploy/helm/templates/NOTES.txt
@@ -1,0 +1,10 @@
+You have installed starboard-operator in the namespace "{{ .Release.Namespace }}"
+and it is configured to operate in the namespaces: '{{ tpl .Values.targetNamespaces . | default "(all namespaces)" }}'.
+
+Inspect created VulnerabilityReports by:
+
+    kubectl get vulnerabilityreports --all-namespaces
+
+Inspect the work log of starboard-operator by:
+
+    kubectl logs -n {{ .Release.Namespace }} deploy/{{ include "starboard-operator.fullname" . }}

--- a/deploy/helm/templates/_helpers.tpl
+++ b/deploy/helm/templates/_helpers.tpl
@@ -1,0 +1,63 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "starboard-operator.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this
+(by the DNS naming spec). If release name contains chart name it will be used
+as a full name.
+*/}}
+{{- define "starboard-operator.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "starboard-operator.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "starboard-operator.labels" -}}
+helm.sh/chart: {{ include "starboard-operator.chart" . }}
+{{ include "starboard-operator.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels.
+*/}}
+{{- define "starboard-operator.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "starboard-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use.
+*/}}
+{{- define "starboard-operator.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "starboard-operator.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -1,0 +1,94 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "starboard-operator.fullname" . }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "starboard-operator.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "starboard-operator.selectorLabels" . | nindent 8 }}
+    spec:
+      containers:
+        - name: "{{ .Chart.Name }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          env:
+            - name: OPERATOR_NAMESPACE
+              value: {{ .Release.Namespace | quote }}
+            - OPERATOR_TARGET_NAMESPACES:
+              value: {{ .Values.targetNamespaces | quote }}
+            - name: OPERATOR_METRICS_BIND_ADDRESS
+              value: ":8080"
+            - name: OPERATOR_HEALTH_PROBE_BIND_ADDRESS
+              value: ":9090"
+            {{- /* Import configuration from passed Helm values */}}
+            {{- range $key, $value := .Values.envSecret.stringData }}
+            {{- if $value }}
+            - name: {{ $key | quote }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.envSecret.name | default (include "starboard-operator.fullname" $) | quote }}
+                  key: {{ $key | quote }}
+                  optional: true
+            {{- end }}
+            {{- end }}
+          ports:
+            - name: metrics
+              containerPort: 8080
+            - name: probes
+              containerPort: 9090
+          readinessProbe:
+            httpGet:
+              path: /readyz/
+              port: probes
+            initialDelaySeconds: 0
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 3
+          livenessProbe:
+            httpGet:
+              path: /healthz/
+              port: probes
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            successThreshold: 1
+            failureThreshold: 10
+          resources:
+            {{- .Values.resources | toYaml | nindent 12 }}
+          {{- with .Values.securityContext }}
+          securityContext:
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
+          {{- with .Values.image.pullPolicy }}
+          imagePullPolicy: {{ . }}
+          {{- end }}
+      {{- with .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "starboard-operator.serviceAccountName" . }}
+      {{- with .Values.podSecurityContext }}
+      securityContext:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- . | toYaml | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/templates/rbac.yaml
+++ b/deploy/helm/templates/rbac.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.serviceAccount.create -}}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "starboard-operator.serviceAccountName" . }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+{{- end }}
+
+{{- if .Values.rbac.create }}
+---
+{{- /*
+Create (Cluster)Role and (Cluster)RoleBinding depending on if the Helm chart is
+installed in a namespace different from the targetNamespace.
+*/}}
+{{- $clusterWide := not (eq .Release.Namespace (tpl .Values.targetNamespaces .)) }}
+{{- $conditionalClusterPrefix := $clusterWide | ternary "Cluster" "" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ $conditionalClusterPrefix }}Role
+metadata:
+  name: {{ include "starboard-operator.fullname" . }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - "pods"
+      - "pods/log"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - batch
+    resources:
+      - jobs
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - delete
+  - apiGroups:
+      - aquasecurity.github.io
+    resources:
+      - vulnerabilityreports
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: {{ $conditionalClusterPrefix }}RoleBinding
+metadata:
+  name: {{ include "starboard-operator.fullname" . }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: {{ $conditionalClusterPrefix }}Role
+  name: {{ include "starboard-operator.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "starboard-operator.serviceAccountName" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/templates/secret.yaml
+++ b/deploy/helm/templates/secret.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.envSecret.create -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.envSecret.name | default (include "starboard-operator.fullname" .) | quote }}
+  labels:
+    {{- include "starboard-operator.labels" . | nindent 4 }}
+stringData:
+  {{- range $key, $value := .Values.envSecret.stringData }}
+  {{ $key | quote }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,0 +1,91 @@
+# Default values for starboard-operator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# targetNamespace defines where you want starboard-operator to operate. By
+# default it will only operate in the namespace its installed in, but you can
+# specify another namespace, or a comma separated list of namespaces, or set it
+# to a blank string to let it operate in all namespaces.
+targetNamespaces: "{{ .Release.Namespace }}"
+
+image:
+  repository: "docker.io/aquasec/starboard-operator"
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "dev"
+  pullPolicy: ""
+  pullSecrets: []
+
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+# envSecret represent a k8s Secret resource that will be referenced to mount
+# environment variables.
+envSecret:
+  # create specifies whether a k8s Secret should be created with a given
+  # stringData. If this is set to false, only the keys defined in stringData
+  # will be optionally mounted from the named secret, rather than all keys in
+  # the named k8s Secret.
+  create: true
+  # name specifies the name of the k8s Secret to reference. If not set, a name
+  # is generated using the fullname template.
+  name: ""
+  # stringData specifies key value pairs to be added to the k8s Secret and
+  # mounted by the Pod as environment variables.
+  #
+  # NOTE: It is important that you specify targetNamespace instead of
+  #       OPERATOR_TARGET_NAMESPACE below for this Helm chart to function
+  #       properly.
+  stringData:
+    OPERATOR_LOG_DEV_MODE: "false"
+    OPERATOR_SCANNER_TRIVY_ENABLED: "true"
+    OPERATOR_SCANNER_TRIVY_VERSION: "0.11.0"
+    OPERATOR_SCANNER_AQUA_CSP_ENABLED: "false"
+    OPERATOR_SCANNER_AQUA_CSP_VERSION: ""
+    OPERATOR_SCANNER_AQUA_CSP_HOST: ""
+    OPERATOR_SCANNER_AQUA_CSP_USER: ""
+    OPERATOR_SCANNER_AQUA_CSP_PASSWORD: ""
+
+rbac:
+  create: true
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  annotations: {}
+  # name specifies the name of the k8s Service Account. If not set and create is
+  # true, a name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext:
+  runAsNonRoot: true
+  allowPrivilegeEscalation: false
+  runAsUser: 65534
+  runAsGroup: 65534
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
Would you be interested in adding a Helm chart to this repository, to allow the starboard-operator to be installed using `helm install ...`?

## PR ambition
In this PR, I've tried to follow the current state of the evolving best practices of Helm charts and created a foundation that will be relatively easy to maintain in the future. As an example, I've tried to avoid the anti-patterns of hardcoding support for a limited set of environment variables which would have needed to be updated as the starboard-operator binary added more configuration options.

## Part of this PR
- [x] Create a Helm chart to install the starboard-operator
- [ ] Create a GitHub Actions CI test running `helm template`.
- [ ] Verify functionality in a k8s cluster.
- [ ] Add a note somewhere describing that this Helm chart is currently not published and use of it is currently to be considered experimental.

## Not part of this PR
- [ ] Create a Helm chart registry where this Helm chart be published
- [ ] Define CI jobs to package and publish the Helm chart to a Helm chart registry
- [ ] Define CI jobs to start a local k8s cluster, install it, and verify it functions

## My background
I have ~3 years of experience writing Helm chart as a maintainer of the [JupyterHub Helm chart](github.com/jupyterhub/zero-to-jupyterhub-k8s) and have contributed to many Helm charts.